### PR TITLE
Support native windows installation of movr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,22 +2,6 @@ include(CheckIncludeFiles)
 
 cmake_minimum_required(VERSION 3.6)
 
-# OS constraint check - movr only supports Linux and macOS
-if(WIN32 AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message(FATAL_ERROR 
-        "movr only supports Linux and macOS. Windows is not supported.\n"
-        "If you need to build on Windows, please use Windows Subsystem for Linux (WSL).\n"
-        "We have tested on Ubuntu and macOS systems."
-    )
-endif()
-
-if(NOT APPLE AND NOT UNIX)
-    message(FATAL_ERROR 
-        "Unsupported operating system. movr only supports Linux and macOS.\n"
-        "We have tested on Ubuntu and macOS systems."
-    )
-endif()
-
 project(movr)
 
 # Global options
@@ -26,9 +10,17 @@ set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
-# Set generator to Unix Makefiles for better portability
-if(NOT CMAKE_GENERATOR)
-    set(CMAKE_GENERATOR "Unix Makefiles" CACHE INTERNAL "" FORCE)
+# Set generator appropriately for each platform
+if(WIN32)
+    # Use appropriate generator for Windows
+    if(NOT CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT CMAKE_GENERATOR MATCHES "MinGW Makefiles")
+        set(CMAKE_GENERATOR "MinGW Makefiles" CACHE INTERNAL "" FORCE)
+    endif()
+else()
+    # Set generator to Unix Makefiles for Linux/macOS
+    if(NOT CMAKE_GENERATOR)
+        set(CMAKE_GENERATOR "Unix Makefiles" CACHE INTERNAL "" FORCE)
+    endif()
 endif()
 
 # Add portability settings
@@ -36,15 +28,33 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-# Suppress warnings from R headers
+# Platform-specific compiler settings
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(-Wno-pedantic -Wno-unknown-pragmas -Wno-unused-parameter)
+elseif(MSVC)
+    # MSVC-specific settings for Windows
+    add_compile_options(/W3)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-# Disable GNU extensions in generated Makefiles
-set(CMAKE_MAKE_PROGRAM "make" CACHE INTERNAL "" FORCE)
-set(CMAKE_GENERATOR_TOOLSET "" CACHE INTERNAL "" FORCE)
-set(CMAKE_MAKE_PROGRAM_FLAGS "" CACHE INTERNAL "" FORCE)
+# Windows-specific settings
+if(WIN32)
+    # Ensure proper Windows API definitions
+    add_definitions(-DWIN32_LEAN_AND_MEAN)
+    # Handle MinGW vs MSVC differences
+    if(MINGW)
+        # MinGW specific settings
+        set(CMAKE_SHARED_LIBRARY_PREFIX "")
+        set(CMAKE_SHARED_LIBRARY_SUFFIX ".dll")
+    endif()
+endif()
+
+# Disable GNU extensions in generated Makefiles for non-Windows platforms
+if(NOT WIN32)
+    set(CMAKE_MAKE_PROGRAM "make" CACHE INTERNAL "" FORCE)
+    set(CMAKE_GENERATOR_TOOLSET "" CACHE INTERNAL "" FORCE)
+    set(CMAKE_MAKE_PROGRAM_FLAGS "" CACHE INTERNAL "" FORCE)
+endif()
 
 # Source files
 set(SOURCES
@@ -65,12 +75,21 @@ include_directories(${R_INCLUDE_DIR} ${GLIB_INCLUDE_DIRS})
 add_library(${CMAKE_PROJECT_NAME} SHARED ${SOURCES})
 target_link_libraries(${CMAKE_PROJECT_NAME} ${LIBS})
 
-# Set output properties for R compatibility
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
-    PREFIX ""
-    SUFFIX ".so"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
-)
+# Set output properties for R compatibility - platform specific
+if(WIN32)
+    set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+        PREFIX ""
+        SUFFIX ".dll"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+else()
+    set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+        PREFIX ""
+        SUFFIX ".so"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+endif()
 
 # Install target
 install(TARGETS ${CMAKE_PROJECT_NAME} DESTINATION lib)

--- a/configure.win
+++ b/configure.win
@@ -1,22 +1,119 @@
 #!/bin/bash
-PKG_ROOT=`dirname $0`
+PKG_ROOT="$(cd "$(dirname "$0")"; pwd)"
 
-if [ -e ${PKG_ROOT}/build ]; then
-rm -rf ${PKG_ROOT}/build
+echo "=== movr Package Windows Build Configuration ==="
+echo "Package root: ${PKG_ROOT}"
+
+# Check if cmake is available
+if ! command -v cmake >/dev/null 2>&1; then
+    echo "Error: cmake is required but not found. Please install cmake."
+    echo "You can download cmake from: https://cmake.org/download/"
+    exit 1
 fi
-mkdir ${PKG_ROOT}/build
 
-cd ${PKG_ROOT}/build && cmake .. && make && cd -
+# Detect build environment
+if command -v gcc >/dev/null 2>&1; then
+    echo "Found GCC compiler (MinGW)"
+    BUILD_ENV="MinGW"
+elif command -v cl >/dev/null 2>&1; then
+    echo "Found MSVC compiler"
+    BUILD_ENV="MSVC"
+else
+    echo "Warning: No suitable compiler found. Trying default..."
+    BUILD_ENV="Default"
+fi
 
-unameOut="$(uname -s)"
+# Clean previous build
+if [ -e "${PKG_ROOT}/build" ]; then
+    echo "Cleaning previous build directory..."
+    rm -rf "${PKG_ROOT}/build"
+fi
+
+# Create build directory
+echo "Creating build directory..."
+mkdir -p "${PKG_ROOT}/build"
+
+# Run cmake configuration
+echo "Running cmake configuration for Windows..."
+cd "${PKG_ROOT}/build"
+
+# Configure based on available build environment
+if [ "$BUILD_ENV" = "MinGW" ]; then
+    echo "Configuring for MinGW..."
+    if ! cmake -G "MinGW Makefiles" -Wno-dev ..; then
+        echo "Error: cmake configuration failed for MinGW"
+        exit 1
+    fi
+    MAKE_CMD="mingw32-make"
+elif [ "$BUILD_ENV" = "MSVC" ]; then
+    echo "Configuring for MSVC..."
+    if ! cmake -Wno-dev ..; then
+        echo "Error: cmake configuration failed for MSVC"
+        exit 1
+    fi
+    MAKE_CMD="cmake --build . --config Release"
+else
+    echo "Trying default cmake configuration..."
+    if ! cmake -Wno-dev ..; then
+        echo "Error: cmake configuration failed"
+        exit 1
+    fi
+    MAKE_CMD="make"
+fi
+
+# Build the library
+echo "Building library with: ${MAKE_CMD}"
+if [ "$BUILD_ENV" = "MSVC" ]; then
+    if ! cmake --build . --config Release; then
+        echo "Error: MSVC build failed"
+        exit 1
+    fi
+else
+    if ! ${MAKE_CMD}; then
+        echo "Error: build failed"
+        exit 1
+    fi
+fi
+
+cd "${PKG_ROOT}"
+
+# Determine library name and check if built
+unameOut="$(uname -s 2>/dev/null || echo "Windows")"
 case "${unameOut}" in
-    Linux*)     libname=movr.so;;
-    Darwin*)    libname=movr.so;;
-    CYGWIN*|MINGW*) libname=movr.dll;;
-    *)          echo "Unknown platform: ${unameOut}"; exit 1;;
+    Linux*|Darwin*) libname=movr.so;;
+    CYGWIN*|MINGW*|MSYS*|Windows*) libname=movr.dll;;
+    *)          libname=movr.dll;;  # Default to dll for unknown Windows variants
 esac
-echo "Machine platform: ${unameOut}"
+echo "Platform: ${unameOut}"
+echo "Expected library: ${libname}"
 
-if [ ! -e ${PKG_ROOT}/libs/${libname} ]; then
-echo "Error: Shared lib not built, exit" && exit 1
+# Check if library was built in src directory
+if [ ! -e "${PKG_ROOT}/src/${libname}" ]; then
+    echo "Error: Shared library ${libname} not found in src directory"
+    echo "Build may have failed or library may be in a different location"
+    
+    # Try to find the library in build directory
+    if [ -e "${PKG_ROOT}/build/${libname}" ]; then
+        echo "Found library in build directory, copying to src..."
+        cp "${PKG_ROOT}/build/${libname}" "${PKG_ROOT}/src/"
+    elif [ -e "${PKG_ROOT}/build/Release/${libname}" ]; then
+        echo "Found library in build/Release directory, copying to src..."
+        cp "${PKG_ROOT}/build/Release/${libname}" "${PKG_ROOT}/src/"
+    elif [ -e "${PKG_ROOT}/build/Debug/${libname}" ]; then
+        echo "Found library in build/Debug directory, copying to src..."
+        cp "${PKG_ROOT}/build/Debug/${libname}" "${PKG_ROOT}/src/"
+    else
+        echo "Could not locate built library"
+        exit 1
+    fi
 fi
+
+echo "Successfully built ${libname} in src directory"
+
+# Clean up build directory to avoid issues with R package build
+if [ -e "${PKG_ROOT}/build" ]; then
+    echo "Cleaning build directory..."
+    rm -rf "${PKG_ROOT}/build"
+fi
+
+echo "=== Windows build completed successfully ==="

--- a/src/Makevars
+++ b/src/Makevars
@@ -13,3 +13,6 @@ else
     PKG_CPPFLAGS = $(shell pkg-config --cflags glib-2.0)
     PKG_LIBS = $(shell pkg-config --libs glib-2.0)
 endif
+
+# Ensure the shared library is named movr.so (not flowmap.so)
+# This is handled by R CMD SHLIB -o movr.so or during package installation

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,35 @@
-# Do nothing but Pass CRAN check
-all:
+# Windows-specific build configuration for movr package
+
+# Compiler flags for Windows
+PKG_CPPFLAGS = -I. -DWIN32_LEAN_AND_MEAN
+
+# Try to find GLib via pkg-config first, fallback to common paths
+PKG_CONFIG_EXISTS = $(shell pkg-config --exists glib-2.0 && echo yes)
+
+ifeq ($(PKG_CONFIG_EXISTS), yes)
+    # Use pkg-config if available
+    PKG_CPPFLAGS += $(shell pkg-config --cflags glib-2.0)
+    PKG_LIBS = $(shell pkg-config --libs glib-2.0)
+else
+    # Fallback for common GLib installation paths on Windows
+    # Users may need to install GLib for Windows (e.g., via MSYS2, vcpkg, or pre-built binaries)
+    PKG_CPPFLAGS += -I$(GLIB_INCLUDE_PATH) -I$(GLIB_INCLUDE_PATH)/glib-2.0 -I$(GLIB_LIB_PATH)/glib-2.0/include
+    PKG_LIBS = -L$(GLIB_LIB_PATH) -lglib-2.0
+endif
+
+# Ensure compatibility with different Windows compilers
+ifeq ($(CC), gcc)
+    # MinGW/GCC specific flags
+    PKG_CPPFLAGS += -std=c99
+    PKG_LIBS += -lws2_32
+else
+    # MSVC specific flags
+    PKG_CPPFLAGS += /TC
+endif
+
+# Default target
+all: $(SHLIB)
+
+# Clean target
+clean:
+	$(RM) *.o *.dll

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -27,6 +27,9 @@ else
     PKG_CPPFLAGS += /TC
 endif
 
+# Ensure the shared library is named movr.dll (not flowmap.dll)
+# This is handled by R CMD SHLIB -o movr.dll or during package installation
+
 # Default target
 all: $(SHLIB)
 

--- a/src/flowmap.c
+++ b/src/flowmap.c
@@ -2,6 +2,18 @@
 #include <Rdefines.h>
 #include <Rinternals.h>
 #include <R_ext/Rdynload.h>
+
+// Windows compatibility
+#ifdef _WIN32
+#include <windows.h>
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
+#ifndef vsnprintf
+#define vsnprintf _vsnprintf
+#endif
+#endif
+
 #include <glib.h>
 
 #include "order.h"


### PR DESCRIPTION
Enable native Windows build support for the movr R package and ensure the shared library is correctly named `movr.dll` for R to load.

The previous configuration explicitly blocked Windows builds in `CMakeLists.txt` and the build process did not consistently produce the `movr.dll` (or `movr.so` on Unix) required by the R package's `useDynLib(movr)` directive. This PR fixes these issues by updating CMake, build scripts, and Makefiles for cross-platform compatibility.